### PR TITLE
Fetch the image from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Git clone locally [this repo](https://github.com/octavian-negru/mfe-fastapi-back
 
 `yarn start` - to run the application. It uses the port 3001. 
 
-Whenever a code change occurs, stop the container with `docker-compose stop`, `yarn build` and then `yarn start`.
+Whenever a code change occurs, stop the app, `yarn build` and then `yarn start`.
 
 
 ## Micro-frontend Remotes

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ An example remote application that exposes itself as a webpack module that can b
 
 Read more about MFE [here](https://micro-frontends.org/). 
 
+## Prerequisites
+Git clone locally [this repo](https://github.com/octavian-negru/mfe-fastapi-backend-example) and get it running.
 
 ## Usage
 
 `yarn` - to install the node packages. 
 
-`yarn start` - to run the application. It uses the port 3002. 
+`yarn start` - to run the application. It uses the port 3001. 
+
+Whenever a code change occurs, stop the container with `docker-compose stop`, `yarn build` and then `yarn start`.
 
 
 ## Micro-frontend Remotes

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import './App.css';
 
 function App() {
   const [dogImg, setDogImg] = useState(null);
   const fetchDoggo = () => {
     setDogImg('');
-    fetch('https://dog.ceo/api/breeds/image/random')
+    const opts = {
+      headers: {
+        mode: 'no-cors'
+      }
+    }
+    fetch('http://localhost:8001/random_dog', opts)
       .then((res) => res.json())
       .then((dogInfo) => {
         setDogImg(dogInfo.message);


### PR DESCRIPTION
Added a [simple backend](https://github.com/octavian-negru/mfe-fastapi-backend-example) for this project.
This PR will use the code from the new backend.
Tested locally with this app and also with the host one, the image gets loaded as before.