### PR TITLE
Make MFEs exchange messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "craco": "^0.0.3",
     "craco-module-federation": "^1.1.0",
+    "pubsub-js": "^1.9.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -10,14 +10,6 @@ const topicSubscriber = (msg, data) => {
 };
 PubSub.subscribe(MFE_TOPIC, topicSubscriber);
 
-const topicSubscriber = (msg, data) => {
-  console.log("Received message in dogs MFE");
-  console.log("msg: ", msg);
-  console.log("data: ", data);
-};
-
-PubSub.subscribe(MFE_TOPIC, topicSubscriber);
-
 function App() {
   const [dogImg, setDogImg] = useState(null);
   const fetchDoggo = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -10,11 +10,24 @@ const topicSubscriber = (msg, data) => {
 };
 PubSub.subscribe(MFE_TOPIC, topicSubscriber);
 
+const topicSubscriber = (msg, data) => {
+  console.log("Received message in dogs MFE");
+  console.log("msg: ", msg);
+  console.log("data: ", data);
+};
+
+PubSub.subscribe(MFE_TOPIC, topicSubscriber);
+
 function App() {
   const [dogImg, setDogImg] = useState(null);
   const fetchDoggo = () => {
     setDogImg('');
-    fetch('https://dog.ceo/api/breeds/image/random')
+    const opts = {
+      headers: {
+        mode: 'no-cors'
+      }
+    }
+    fetch('http://localhost:8001/random_dog', opts)
       .then((res) => res.json())
       .then((dogInfo) => {
         setDogImg(dogInfo.message);

--- a/src/App.js
+++ b/src/App.js
@@ -3,17 +3,15 @@ import React, { useEffect, useState } from 'react';
 import './App.css';
 
 const MFE_TOPIC = 'MFE Topic';
+const topicSubscriber = (msg, data) => {
+  console.log("Received message in dogs MFE");
+  console.log("msg: ", msg);
+  console.log("data: ", data);
+};
+PubSub.subscribe(MFE_TOPIC, topicSubscriber);
 
 function App() {
   const [dogImg, setDogImg] = useState(null);
-
-  const topicSubscriber = (msg, data) => {
-    console.log("Received message in dogs MFE");
-    console.log("msg: ", msg);
-    console.log("data: ", data);
-  };
-  PubSub.subscribe(MFE_TOPIC, topicSubscriber);
-
   const fetchDoggo = () => {
     setDogImg('');
     fetch('https://dog.ceo/api/breeds/image/random')

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import PubSub from 'pubsub-js';
+import React, { useEffect, useState } from 'react';
 import './App.css';
+
+const MFE_TOPIC = 'MFE Topic';
 
 function App() {
   const [dogImg, setDogImg] = useState(null);
+
+  const topicSubscriber = (msg, data) => {
+    console.log("Received message in dogs MFE");
+    console.log("msg: ", msg);
+    console.log("data: ", data);
+  };
+  PubSub.subscribe(MFE_TOPIC, topicSubscriber);
+
   const fetchDoggo = () => {
     setDogImg('');
     fetch('https://dog.ceo/api/breeds/image/random')
@@ -16,14 +27,18 @@ function App() {
     if (dogImg == null) {
       fetchDoggo();
     }
-  });
+  }, [dogImg]);
 
   return (
     <div>
       <header>
         <h3>Doggo of the day</h3>
         <div>
-          <button onClick={() => fetchDoggo()}>New Doggo</button>
+          <button onClick={() => {
+            const randomId = (Math.random() + 1).toString(36).substring(7);
+            PubSub.publish(MFE_TOPIC, randomId);
+            fetchDoggo();
+          }}>New Doggo</button>
         </div>
         {dogImg !== "" ? (
           <div>

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import './index.css';
+import App from './App';
+import reportWebVitals from './reportWebVitals';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);
+
+// If you want to start measuring performance in your app, pass a function
+// to log results (for example: reportWebVitals(console.log))
+// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+reportWebVitals();

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,4 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import('./bootstrap.js');
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root')
-);
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+// Using bootstrap.js to avoid Uncaught Error: Shared module is not available for eager consumption
+// https://www.linkedin.com/pulse/uncaught-error-shared-module-available-eager-rany-elhousieny-phd%E1%B4%AC%E1%B4%AE%E1%B4%B0?trk=articles_directory

--- a/yarn.lock
+++ b/yarn.lock
@@ -8268,6 +8268,11 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
+pubsub-js@^1.9.4:
+  version "1.9.4"
+  resolved "https://eq-ai-711361523013.d.codeartifact.us-east-1.amazonaws.com:443/npm/omni-js/pubsub-js/-/pubsub-js-1.9.4.tgz#5c8678600e34e95b1269e96c17e1b51dab3ecb5a"
+  integrity sha512-hJYpaDvPH4w8ZX/0Fdf9ma1AwRgU353GfbaVfPjfJQf1KxZ2iHaHl3fAUw1qlJIR5dr4F3RzjGaWohYUEyoh7A==
+
 pump@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"


### PR DESCRIPTION
ODA-4994

Tested with the host MFE.
On button, click, inspect the Console logs.
The messages are shared between the MFEs.

Added a [simple backend](https://github.com/octavian-negru/mfe-fastapi-backend-example) for this project.
This PR will use the code from the new backend.
Tested locally with this app and also with the host one, the image gets loaded as before.